### PR TITLE
feat: add direction support for literals

### DIFF
--- a/DatasetCore.js
+++ b/DatasetCore.js
@@ -35,7 +35,7 @@ function termToId (term) {
 
     case 'Literal':
       if (term.language) {
-        return `"${term.value}"@${term.language}`
+        return `"${term.value}"@${term.language}${term.direction ? `--${term.direction}` : ''}`
       }
 
       return `"${term.value}"${term.datatype && term.datatype.value !== xsdString ? `^^${term.datatype.value}` : ''}`

--- a/test/DatasetCore.test.js
+++ b/test/DatasetCore.test.js
@@ -142,6 +142,42 @@ function runTests ({ factory, mocha }) {
         strictEqual(dataset.has(quadB), true)
       })
 
+      it('should support Quads with directional language Literals', () => {
+        const quadA = rdf.quad(ex.subject, ex.predicate, rdf.literal('test', { language: 'en', direction: 'ltr' }))
+        const quadB = rdf.quad(ex.subject, ex.predicate, rdf.literal('test', { language: 'en', direction: 'rtl' }))
+        const dataset = factory.dataset()
+
+        dataset.add(quadA)
+
+        strictEqual(dataset.size, 1)
+        strictEqual(dataset.has(quadA), true)
+        strictEqual(dataset.has(quadB), false)
+
+        dataset.add(quadB)
+
+        strictEqual(dataset.size, 2)
+        strictEqual(dataset.has(quadA), true)
+        strictEqual(dataset.has(quadB), true)
+      })
+
+      it('should support Quads with directional and non-directional Literals using the same language', () => {
+        const quadA = rdf.quad(ex.subject, ex.predicate, rdf.literal('test', 'en'))
+        const quadB = rdf.quad(ex.subject, ex.predicate, rdf.literal('test', { language: 'en', direction: 'ltr' }))
+        const dataset = factory.dataset()
+
+        dataset.add(quadA)
+
+        strictEqual(dataset.size, 1)
+        strictEqual(dataset.has(quadA), true)
+        strictEqual(dataset.has(quadB), false)
+
+        dataset.add(quadB)
+
+        strictEqual(dataset.size, 2)
+        strictEqual(dataset.has(quadA), true)
+        strictEqual(dataset.has(quadB), true)
+      })
+
       it('should support Quads with datatype Literals', () => {
         const quadA = rdf.quad(ex.subject, ex.predicate, rdf.literal('123', ex.datatypeA))
         const quadB = rdf.quad(ex.subject, ex.predicate, rdf.literal('123', ex.datatypeB))


### PR DESCRIPTION
## Summary
- `DatasetCore`'s internal literal index key now incorporates the `direction` property, so directional language-tagged literals (`rdf:dirLangString`) that differ only by direction are no longer collapsed to the same index key.
- This closes a gap where `add`/`has`/`delete`/`match` would have treated e.g. `"test"@en--ltr` and `"test"@en--rtl` as the same quad, even though `@rdfjs/data-model`'s `Literal.equals()` correctly treats them as distinct per the [data-model spec](https://rdf.js.org/data-model-spec/#literal-interface).